### PR TITLE
Change load order of server customizations

### DIFF
--- a/opr-core/src/server/oprserver.ts
+++ b/opr-core/src/server/oprserver.ts
@@ -327,12 +327,17 @@ export class OprServer {
   }
 
   private async initializeServer() {
+    // core server components
     this.app.use(expressJson());
     this.serveOrgFile();
     this.maybeServeJwks();
     this.serveApiEndpoints();
-    this.serveCustomEndpoints();
+
+    // user customizations
     await this.doCustomStartup();
+    this.serveCustomEndpoints();
+
+    // catch unhandled errors
     this.app.use(
       // NOTE: This handler must be registered last, and it MUST have the
       // unused 'next' parameter as its last argument.


### PR DESCRIPTION
During the OprServer setup, custom startup routines are currently loaded _after_ custom endpoints. This moves the execution of custom startup routines before the endpoints, allowing users to make changes to the Express app prior to their custom endpoints being loaded.