### PR TITLE
Better fix for multiple outputs from schema compiler

### DIFF
--- a/opr-models/src/jsonpatch.schema.json
+++ b/opr-models/src/jsonpatch.schema.json
@@ -2,6 +2,7 @@
   "$id": "jsonpatch.schema.json",
   "$schema": "http://json-schema.org/draft-04/schema#",
   "comment": "Copied and reformatted from source at https://json.schemastore.org/json-patch.json",
+  "description": "A JSON Patch array",
   "examples": [
     [
       {
@@ -12,57 +13,7 @@
     ]
   ],
   "items": {
-    "oneOf": [
-      {
-        "additionalProperties": false,
-        "required": ["value", "op", "path"],
-        "properties": {
-          "path": {
-            "$ref": "jsonpath.schema.json"
-          },
-          "op": {
-            "description": "The operation to perform.",
-            "type": "string",
-            "enum": ["add", "replace", "test"]
-          },
-          "value": {
-            "description": "The value to add, replace or test."
-          }
-        }
-      },
-      {
-        "additionalProperties": false,
-        "required": ["op", "path"],
-        "properties": {
-          "path": {
-            "$ref": "jsonpath.schema.json"
-          },
-          "op": {
-            "description": "The operation to perform.",
-            "type": "string",
-            "enum": ["remove"]
-          }
-        }
-      },
-      {
-        "additionalProperties": false,
-        "required": ["from", "op", "path"],
-        "properties": {
-          "path": {
-            "$ref": "jsonpath.schema.json"
-          },
-          "op": {
-            "description": "The operation to perform.",
-            "type": "string",
-            "enum": ["move", "copy"]
-          },
-          "from": {
-            "$ref": "jsonpath.schema.json",
-            "description": "A JSON Pointer path pointing to the location to move/copy from."
-          }
-        }
-      }
-    ]
+    "$ref" : "jsonpatchop.schema.json"
   },
   "title": "JSONPatch",
   "type": "array"

--- a/opr-models/src/jsonpatchop.schema.json
+++ b/opr-models/src/jsonpatchop.schema.json
@@ -1,0 +1,65 @@
+{
+  "$id": "jsonpatchop.schema.json",
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "comment": "Copied and reformatted from source at https://json.schemastore.org/json-patch.json",
+  "description": "A JSON Patch operation",
+  "examples": [
+    {
+      "op": "replace",
+      "path": "",
+      "value": {}
+    }
+  ],
+  "title": "JSONPatchOp",
+  "oneOf": [
+    {
+      "additionalProperties": false,
+      "required": ["value", "op", "path"],
+      "properties": {
+        "path": {
+          "$ref": "jsonpath.schema.json"
+        },
+        "op": {
+          "description": "The operation to perform.",
+          "type": "string",
+          "enum": ["add", "replace", "test"]
+        },
+        "value": {
+          "description": "The value to add, replace or test."
+        }
+      }
+    },
+    {
+      "additionalProperties": false,
+      "required": ["op", "path"],
+      "properties": {
+        "path": {
+          "$ref": "jsonpath.schema.json"
+        },
+        "op": {
+          "description": "The operation to perform.",
+          "type": "string",
+          "enum": ["remove"]
+        }
+      }
+    },
+    {
+      "additionalProperties": false,
+      "required": ["from", "op", "path"],
+      "properties": {
+        "path": {
+          "$ref": "jsonpath.schema.json"
+        },
+        "op": {
+          "description": "The operation to perform.",
+          "type": "string",
+          "enum": ["move", "copy"]
+        },
+        "from": {
+          "$ref": "jsonpath.schema.json",
+          "description": "A JSON Pointer path pointing to the location to move/copy from."
+        }
+      }
+    }
+  ]
+}

--- a/opr-models/src/types-generated/schemas.ts
+++ b/opr-models/src/types-generated/schemas.ts
@@ -22,6 +22,7 @@ export {default as DecodedReshareChainLink} from '../decodedresharechainlink.sch
 export {default as HistoryPayload} from '../history.payload.schema.json';
 export {default as HistoryResponse} from '../history.response.schema.json';
 export {default as JSONPatch} from '../jsonpatch.schema.json';
+export {default as JSONPatchOp} from '../jsonpatchop.schema.json';
 export {default as JSONPath} from '../jsonpath.schema.json';
 export {default as LatLong} from '../latlong.schema.json';
 export {default as ListOffersPayload} from '../list.payload.schema.json';

--- a/opr-models/src/types-generated/types.ts
+++ b/opr-models/src/types-generated/types.ts
@@ -73,7 +73,15 @@ export interface HistoryResponse {
   offerHistories: OfferHistory[];
 }
 
-export type JSONPatch = (
+/**
+ * A JSON Patch array
+ */
+export type JSONPatch = JSONPatchOp[];
+
+/**
+ * A JSON Patch operation
+ */
+export type JSONPatchOp =
   | {
       path: JSONPath;
       /**
@@ -101,8 +109,7 @@ export type JSONPatch = (
        */
       op: 'move' | 'copy';
       from: JSONPath;
-    }
-)[];
+    };
 
 /**
  * A JSON Pointer path.
@@ -401,6 +408,8 @@ export interface SchemaNameToType {
   ['history.response.schema.json']: HistoryResponse;
   JSONPatch: JSONPatch;
   ['jsonpatch.schema.json']: JSONPatch;
+  JSONPatchOp: JSONPatchOp;
+  ['jsonpatchop.schema.json']: JSONPatchOp;
   JSONPath: JSONPath;
   ['jsonpath.schema.json']: JSONPath;
   LatLong: LatLong;


### PR DESCRIPTION
Fixes #47 

The schema compiler library we uses contains a bug wherein it sometimes outputs the same interface or type definition for multiple input files. For example, for the json schema files in this PR, the schema compiler outputs the JSONPatchOp interface definition when it compiles jsonpatchop.schema.json AND when it compiles jsonpatch.schema.json. Since these outputs are merged into a single types.ts file, these redefinitions cause compiler errors (and are confusing and wasteful).

compileschema.ts contained an attempted fix for this problem, but that fix incorrectly assumed that the correct type would appear in the file first. This new fix does not contain that assumption.

The fix is checked in along with a schema change that triggered the problem.