### PR TITLE
Fixes issue building docker on M1 Macs

### DIFF
--- a/examples/gcp-cloudrun-postgres/README.md
+++ b/examples/gcp-cloudrun-postgres/README.md
@@ -127,7 +127,7 @@ Note: Depending on how you have docker set up, you may need to run docker as roo
 From a terminal, build the server by running the command:
 
 ```console
-docker build --no-cache -t gcr.io/YOUR_PROJECT_ID/example-server .
+docker build --no-cache --platform linux/amd64 -t gcr.io/YOUR_PROJECT_ID/example-server .
 ```
 
 Replace `YOUR_PROJECT_ID` above with the id of your Google Cloud project.


### PR DESCRIPTION
Fixes #58

Docker build on mac with M1 chips would fail to connect in GCP.  Adding the platform argument fixes it.
https://cloud.google.com/run/docs/container-contract
"Executables in the container image must be compiled for Linux 64-bit. Cloud Run specifically supports the Linux x86_64 ABI format."

- [X] Tests pass
- [X] Appropriate changes to README are included in PR