### PR TITLE
Fix a bug in the history api and expose history in the GCP example server

### DIFF
--- a/components/core/src/integrations/integrationapi.ts
+++ b/components/core/src/integrations/integrationapi.ts
@@ -104,7 +104,7 @@ export interface IntegrationApi {
    */
   getLocalAcceptHistory(
     sinceTimestampUTC?: number
-  ): AsyncIterator<OfferHistory>;
+  ): AsyncIterable<OfferHistory>;
 
   /**
    * Returns the history of offers accepted FROM THE GIVEN HOST. If the

--- a/components/core/src/server/integrationapiimpl.ts
+++ b/components/core/src/server/integrationapiimpl.ts
@@ -265,7 +265,7 @@ export class IntegrationApiImpl implements IntegrationApi {
 
   async *getLocalAcceptHistory(
     sinceTimestampUTC?: number | undefined
-  ): AsyncIterator<OfferHistory> {
+  ): AsyncIterable<OfferHistory> {
     const t = await this.storage.createTransaction('READONLY');
     const iterable = this.storage.getHistory(
       t,

--- a/examples/gcp-cloudrun-postgres/src/index.ts
+++ b/examples/gcp-cloudrun-postgres/src/index.ts
@@ -31,7 +31,7 @@ import {
 } from 'opr-core';
 import yargs from 'yargs';
 import * as dotenv from 'dotenv';
-log.setLevel('WARN');
+log.setLevel('INFO');
 import {DataSourceOptions, SqlOprPersistentStorage} from 'opr-sql-database';
 import {
   CloudStorageJwksProvider,
@@ -129,7 +129,7 @@ async function main() {
   // organization config file, and how to map its contents to server endpoints.
   const frontendConfig = {
     // Replace with your organization name
-    name: 'ExampleServer',
+    name: "John' Home Server",
     // Replace with your organization's public org descriptor URL
     organizationURL: `${hostname}/org.json`,
     orgFilePath: '/org.json',
@@ -239,6 +239,15 @@ async function main() {
         },
       })
     );
+
+    // Create a custom endpoint that will display the offer acceptance history.
+    const historyEndpoint = {
+      method: ['POST', 'GET'],
+      handle: async () => {
+        return await asyncIterableToArray(api.getLocalAcceptHistory());
+      },
+    } as CustomRequestHandler;
+    api.installCustomHandler('history', historyEndpoint);
 
     // Create a custom endpoint that will call server.ingest() to pull in any
     // new offers, and return any changes that occurred.

--- a/examples/gcp-cloudrun-postgres/src/index.ts
+++ b/examples/gcp-cloudrun-postgres/src/index.ts
@@ -31,7 +31,7 @@ import {
 } from 'opr-core';
 import yargs from 'yargs';
 import * as dotenv from 'dotenv';
-log.setLevel('INFO');
+log.setLevel('WARN');
 import {DataSourceOptions, SqlOprPersistentStorage} from 'opr-sql-database';
 import {
   CloudStorageJwksProvider,
@@ -129,7 +129,7 @@ async function main() {
   // organization config file, and how to map its contents to server endpoints.
   const frontendConfig = {
     // Replace with your organization name
-    name: "John' Home Server",
+    name: 'ExampleServer',
     // Replace with your organization's public org descriptor URL
     organizationURL: `${hostname}/org.json`,
     orgFilePath: '/org.json',


### PR DESCRIPTION
Add a public history endpoint to the example server so users can be sure whether their offer acceptances worked.