### PR TITLE
add OPR user agent to defaultjsonfetcher

### DIFF
--- a/components/core/src/net/defaultjsonfetcher.ts
+++ b/components/core/src/net/defaultjsonfetcher.ts
@@ -40,6 +40,7 @@ export class DefaultJsonFetcher implements JsonFetcher {
     const headers = new Headers(reqInit?.headers);
     if (reqInit?.body && !headers.has('Content-Type')) {
       headers.set('Content-Type', 'application/json');
+      headers.set('User-Agent', 'OpenProductRecovery'); //todo: add version?
     }
     return headers;
   }


### PR DESCRIPTION
This adds an OpenProductRecovery user agent to the getHeaders method in defaultjsonfetcher.ts.